### PR TITLE
Make it easier to read/use the benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@
 
 # Assignment-specific things to ignore
 SpatialDataStructuresBenchmark
+
+*.csv
+*.pdf
+*.swp
+*.DS_Store
+*.nfs*

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 CC = g++
 
+CC_FLAGS = -Wall -Wextra -std=c++11 -O3
+
 # include variables from other makefiles for each type of library
 include *.sdbs.mk
-
-CC_FLAGS = -Wall -Wextra -std=c++11 -O3
 
 TARGETS = SpatialDataStructuresBenchmark
 
@@ -13,6 +13,6 @@ SpatialDataStructuresBenchmark: SpatialDataStructuresBenchmark.cc PointScenarioG
 	$(CC) $< -o $@ $(CC_INCLUDE) $(LD_FLAGS) $(CC_FLAGS)
 
 clean:
-	rm -f $(TARGETS)
+	rm -f $(TARGETS) *.o
 
 again: clean $(TARGETS)

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,15 @@
 CC = g++
 
-STLIB_INCLUDE_PATH = /research/jeff/stlib
-PCL_INCLUDE_PATH = /research/jeff/pcl/usr/local/include/pcl-1.8/
-PCL_LIB_PATH = /research/jeff/pcl/usr/local/lib
-#KDTREE2_INCLUDE_PATH = /clinic/2015/sandia15/something
-#KDTREE2_LIB_PATH = /clinic/2015/sandia15/something
+# include variables from other makefiles for each type of library
+include *.sdbs.mk
 
-CC_INCLUDE = -I$(PCL_INCLUDE_PATH) -I$(STLIB_INCLUDE_PATH)
 CC_FLAGS = -Wall -Wextra -std=c++11 -O3
-LD_FLAGS = -L$(PCL_LIB_PATH) -lpcl_kdtree -lpcl_octree 
-# -L$(KDTREE2_LIB_PATH) -lkdtree2
 
 TARGETS = SpatialDataStructuresBenchmark
 
 all: $(TARGETS)
 
-SpatialDataStructuresBenchmark: SpatialDataStructuresBenchmark.cc PointScenarioGenerators.h Versions_stlib.h Versions_pcl.h 
+SpatialDataStructuresBenchmark: SpatialDataStructuresBenchmark.cc PointScenarioGenerators.h $(VERSIONS) 
 	$(CC) $< -o $@ $(CC_INCLUDE) $(LD_FLAGS) $(CC_FLAGS)
 
 clean:

--- a/SpatialDataStructuresBenchmark.h
+++ b/SpatialDataStructuresBenchmark.h
@@ -1,0 +1,67 @@
+#ifndef SPATIAL_DATA_STRUCTURES_BENCHMARK_H
+#define SPATIAL_DATA_STRUCTURES_BENCHMARK_H
+
+#include "CommonDefinitions.h"
+
+#include <string>
+#include <vector>
+#include <limits>
+#include <functional>
+#include <utility>
+
+using Function = std::function<
+  void(const std::vector<Point>,
+       const BoundingBox,
+       const double,
+       std::vector<unsigned int> * const,
+       std::vector<unsigned int> * const,
+       double * const,
+       double * const)>;
+
+extern std::vector<std::pair<Function, std::string>> functions;
+
+void
+checkResult(const std::vector<unsigned int> & correctResult,
+            const std::vector<unsigned int> & correctResultDelimiters,
+            const std::vector<unsigned int> & testResult,
+            const std::vector<unsigned int> & testResultDelimiters,
+            const std::string & testName);
+
+template <class Function>
+void
+runTest(const unsigned int numberOfTrials,
+        const Function function,
+        const std::vector<Point> & points,
+        const BoundingBox & pointsBoundingBox,
+        const double neighborSearchDistance,
+        std::vector<unsigned int> * const result,
+        std::vector<unsigned int> * const resultDelimiters,
+        double * const initializationTime,
+        double * const queryingTime) {
+
+  *initializationTime = std::numeric_limits<double>::max();
+  *queryingTime = std::numeric_limits<double>::max();
+
+  for (unsigned int trialNumber = 0;
+       trialNumber < numberOfTrials; ++trialNumber) {
+
+    double thisTrialsInitializationTime = std::numeric_limits<double>::max();
+    double thisTrialsQueryingTime = std::numeric_limits<double>::max();
+
+    result->resize(0);
+    resultDelimiters->resize(0);
+
+    // Do the test
+    function(points, pointsBoundingBox, neighborSearchDistance,
+             result, resultDelimiters,
+             &thisTrialsInitializationTime, &thisTrialsQueryingTime);
+
+    // Take the minimum values from all trials
+    *initializationTime =
+      std::min(*initializationTime, thisTrialsInitializationTime);
+    *queryingTime =
+      std::min(*queryingTime, thisTrialsQueryingTime);
+  }
+
+}
+#endif // DEFINED SPATIAL_DATA_STRUCTURES_BENCHMARK_H

--- a/Versions_kdtree2.h
+++ b/Versions_kdtree2.h
@@ -3,6 +3,7 @@
 #define VERSIONS_KDTREE2_H
 
 #include "CommonDefinitions.h"
+#include "SpatialDataStructuresBenchmark.h"
 
 // kdtree2 include
 #include "kdtree2.hpp"
@@ -14,7 +15,7 @@ using std::chrono::duration_cast;
 
 
 void
-findNeighbors_kdtree2(const vector<Point> & points,
+findneighbors_kdtree2(const vector<Point> & points,
                       const BoundingBox & pointsBoundingBox,
                       const double neighborSearchDistance,
                       vector<unsigned int> * const result,
@@ -79,7 +80,8 @@ findNeighbors_kdtree2(const vector<Point> & points,
     duration_cast<duration<double> >(initializationToc - initializationTic).count();
   *queryingTime =
     duration_cast<duration<double> >(queryingToc - initializationToc).count();
-
 }
+
+functions.push_back(std::make_pair("kdtree2", findneighbors_kdtree2));
 
 #endif // VERSIONS_KDTREE2_H

--- a/Versions_pcl.h
+++ b/Versions_pcl.h
@@ -2,95 +2,15 @@
 #ifndef VERSIONS_PCL_H
 #define VERSIONS_PCL_H
 
-//#include "CommonDefinitions.h"
-
 // pcl includes
 #include <pcl/octree/octree.h>
 #include <pcl/point_cloud.h>
 #include <pcl/kdtree/kdtree_flann.h>
-//#include <stlib/geom/orq/CellArrayNeighbors.h>
 
 // a little naughty, yeah.
 using std::chrono::high_resolution_clock;
 using std::chrono::duration;
 using std::chrono::duration_cast;
-
-/*void
-findNeighbors_pclOctree(const vector<Point> & points,
-                                                const BoundingBox & pointsBoundingBox,
-                                                const double neighborSearchDistance,
-                                                vector<unsigned int> * const result,
-                                                vector<unsigned int> * const resultDelimiters,
-                                                double * const initializationTime,
-                                                double * const queryingTime) {
-    ignoreUnusedVariable(pointsBoundingBox);
-
-    const double neighborSearchDistanceSquared =
-    neighborSearchDistance * neighborSearchDistance;
-    const double paddedNeighborSearchDistance = neighborSearchDistance * 1.001;
-
-    const high_resolution_clock::time_point initializationTic =
-        high_resolution_clock::now();
-
-    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZ>);
-
-    // Generate pointcloud
-    cloud->points.resize(points.size());
-
-    for (size_t i=0; i < points.size(); ++i) {
-        cloud->points[i].x = points[i][0];
-        cloud->points[i].y = points[i][1];
-        cloud->points[i].z = points[i][2];
-    }
-
-    // set octree resolution. using given number from pcl octree example
-    float resolution = 128.0f;
-
-    pcl::octree::OctreePointCloudSearch<pcl::PointXYZ> octree (resolution);
-
-    octree.setInputCloud (cloud);
-    octree.addPointsFromInputCloud ();
-
-    // track how long it took to initialize octree
-    const high_resolution_clock::time_point initializationToc =
-        high_resolution_clock::now();
-
-    resultDelimiters->push_back(0);
-
-    const unsigned int numberOfPoints = points.size();
-    vector<typename vector<Point>::const_iterator> thisPointsNeighborhood;
-    for (unsigned int pointIndex = 0; pointIndex < numberOfPoints; ++pointIndex) {
-        pcl::PointXYZ thisPoint;
-        thisPoint.x = points[pointIndex][0];
-        thisPoint.y = points[pointIndex][1];
-        thisPoint.z = points[pointIndex][2];
-
-        std::vector<int> pointIdxRadiusSearch;
-        std::vector<float> pointRadiusSquaredDistance;
-
-        octree.radiusSearch( thisPoint, neighborSearchDistance,
-            pointIdxRadiusSearch, pointRadiusSquaredDistance);
-
-        for (const auto it : pointIdxRadiusSearch) {
-            if (squaredMagnitude(points[it] - points[pointIndex]) <=
-                    neighborSearchDistanceSquared) {
-                result->push_back(it);
-            }
-        }
-
-        resultDelimiters->push_back(result->size());
-    }
-                     
-    const high_resolution_clock::time_point queryingToc =
-        high_resolution_clock::now();
-
-    *initializationTime =
-        duration_cast<duration<double> >(initializationToc - initializationTic).count();
-    *queryingTime =
-        duration_cast<duration<double> >(queryingToc - initializationToc).count();
-
-
-}*/
 
 void
 findNeighbors_pclOctree(const vector<Point> & points,
@@ -169,7 +89,6 @@ findNeighbors_pclOctree(const vector<Point> & points,
 
 }
 
-
 void
 findNeighbors_pclKdTree(const vector<Point> & points,
                                                 const BoundingBox & pointsBoundingBox,
@@ -238,7 +157,6 @@ findNeighbors_pclKdTree(const vector<Point> & points,
         duration_cast<duration<double> >(initializationToc - initializationTic).count();
     *queryingTime =
         duration_cast<duration<double> >(queryingToc - initializationToc).count();
-
-
 }
+
 #endif // VERSIONS_PCL_H

--- a/Versions_stlib.h
+++ b/Versions_stlib.h
@@ -1,8 +1,9 @@
-// -*- C++ -*-
 #ifndef VERSIONS_STLIB_H
 #define VERSIONS_STLIB_H
 
 #include "CommonDefinitions.h"
+
+#include <vector>
 
 // stlib includes
 #include <stlib/geom/orq/Octree.h>
@@ -10,6 +11,7 @@
 #include <stlib/geom/orq/CellArrayNeighbors.h>
 
 // a little naughty, yeah.
+using std::vector;
 using std::chrono::high_resolution_clock;
 using std::chrono::duration;
 using std::chrono::duration_cast;
@@ -194,8 +196,6 @@ findNeighbors_stlibKdTree(const vector<Point> & points,
     duration_cast<duration<double> >(initializationToc - initializationTic).count();
   *queryingTime =
     duration_cast<duration<double> >(queryingToc - initializationToc).count();
-
-
 }
+#endif // DEFINED VERSIONS_STLIB_H
 
-#endif // VERSIONS_STLIB_H

--- a/generatePlots.py
+++ b/generatePlots.py
@@ -16,12 +16,11 @@ pointGeneratorName = 'uniformRandomWithAverageNumberOfNeighbors'
 prefix = 'data/SpatialDataStructuresBenchmark_' + pointGeneratorName + '_'
 suffix = '_knuth'
 outputPrefix = 'figures/SpatialDataStructuresBenchmark_' + pointGeneratorName + '_'
-
-stlib_cellArray = numpy.loadtxt(open(prefix + 'stlib_cellArray_results' + suffix + '.csv','rb'),delimiter=',',skiprows=0)
-stlib_octTree = numpy.loadtxt(open(prefix + 'stlib_octTree_results' + suffix + '.csv','rb'),delimiter=',',skiprows=0)
-stlib_kdTree = numpy.loadtxt(open(prefix + 'stlib_kdTree_results' + suffix + '.csv','rb'),delimiter=',',skiprows=0)
-pcl_kdTree = numpy.loadtxt(open(prefix + 'pcl_kdTree_results' + suffix + '.csv','rb'),delimiter=',',skiprows=0)
-pcl_ocTree = numpy.loadtxt(open(prefix + 'pcl_ocTree_results' + suffix + '.csv','rb'),delimiter=',',skiprows=0)
+stlib_cellArray = numpy.loadtxt(open(prefix + 'stlib_cellarray_results' + suffix + '.csv','rb'),delimiter=',',skiprows=0)
+stlib_octTree = numpy.loadtxt(open(prefix + 'stlib_octree_results' + suffix + '.csv','rb'),delimiter=',',skiprows=0)
+stlib_kdTree = numpy.loadtxt(open(prefix + 'stlib_kdtree_results' + suffix + '.csv','rb'),delimiter=',',skiprows=0)
+pcl_kdTree = numpy.loadtxt(open(prefix + 'pcl_kdtree_results' + suffix + '.csv','rb'),delimiter=',',skiprows=0)
+pcl_ocTree = numpy.loadtxt(open(prefix + 'pcl_octree_results' + suffix + '.csv','rb'),delimiter=',',skiprows=0)
 #kdtree2 = numpy.loadtxt(open(prefix + 'kdtree2_results' + suffix + '.csv','rb'),delimiter=',',skiprows=0)
 
 for column in range(1, 3):

--- a/kdtree2.sdbs.mk
+++ b/kdtree2.sdbs.mk
@@ -1,0 +1,6 @@
+#KDTREE2_INCLUDE_PATH = /clinic/2015/sandia15/something
+#KDTREE2_LIB_PATH = /clinic/2015/sandia15/something
+
+#LD_FLAGS += -L$(KDTREE2_LIB_PATH) -lkdtree2
+#CC_INCLUDE += -isystem $(KDTREE2_INCLUDE_PATH)
+#VERSIONS += Version_kdtree2.h

--- a/pcl.sdbs.mk
+++ b/pcl.sdbs.mk
@@ -1,0 +1,6 @@
+PCL_INCLUDE_PATH = /research/jeff/pcl/usr/local/include/pcl-1.8/
+PCL_LIB_PATH = /research/jeff/pcl/usr/local/lib
+
+CC_INCLUDE += -isystem $(PCL_INCLUDE_PATH)
+LD_FLAGS += -L$(PCL_LIB_PATH) -lpcl_kdtree -lpcl_octree 
+VERSIONS += Versions_pcl.h

--- a/stlib.sdbs.mk
+++ b/stlib.sdbs.mk
@@ -1,0 +1,4 @@
+STLIB_INCLUDE_PATH = /research/jeff/stlib
+
+CC_INCLUDE += -isystem $(STLIB_INCLUDE_PATH)
+VERSIONS += Versions_stlib.h 

--- a/stlib.sdbs.mk
+++ b/stlib.sdbs.mk
@@ -1,4 +1,5 @@
 STLIB_INCLUDE_PATH = /research/jeff/stlib
 
 CC_INCLUDE += -isystem $(STLIB_INCLUDE_PATH)
-VERSIONS += Versions_stlib.h 
+VERSIONS += Versions_stlib.h
+


### PR DESCRIPTION
The goal here was to make it a lot easier to add other structures to the benchmark.  The general workflow would now look like this:
- Create a new library.sdbm.mk file (a Makefile) that creates any variables you need, and add the include path to `CC_INCLUDE` and the link path to `LD_FLAGS`. Add any dependencies for your stuff to `VERSIONS`
- The main Makefile will then include all files with the extension `.sdbm.mk` so your values will be included
- Then edit `SpatialDataStructureBenchmark.cc` to include a line at the top indicating the function you want to use for the test, and a string readable name to use with it.

To do this I made the main file a lot more generic and took advantage of templates and loops so as to avoid a lot of the repeated hardcoding.

I wanted to find a way to just link an object file that updates the `functions` global, but I haven't figured out how to do that, nor do I think I will be able to.
